### PR TITLE
feat: add thanos callback urls

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,8 @@ resource "aws_cognito_user_pool_client" "client" {
     format("https://argocd.apps.%s.%s/auth/callback", var.cluster_name, var.base_domain),
     format("https://grafana.apps.%s.%s/login/generic_oauth", var.cluster_name, var.base_domain),
     format("https://prometheus.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
+    format("https://thanos-query.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
+    format("https://thanos-bucketweb.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
     format("https://alertmanager.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "argocd_namespace" {
 
 variable "namespace" {
   type    = string
-  default = "cert-manager"
+  default = "default"
 }
 
 variable "dependency_ids" {


### PR DESCRIPTION
This PR adds the callback URLs needed to provide an OIDC proxy to the Thanos web interfaces. I've simply hard coded the URLs as we have done before, but I think in the future (as suggested by @jbarascut) it would be better to not provide any callback URL for a module that is not deployed. However that it outside the scope of this PR and something we should discuss in the future.