### PR TITLE
fix: remove optional from variable used to create users

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -226,8 +226,8 @@ Type:
 map(object({
     username   = string
     email      = string
-    first_name = optional(string)
-    last_name  = optional(string)
+    first_name = string
+    last_name  = string
   }))
 ----
 
@@ -350,8 +350,8 @@ Description: ID of the Cognito user pool. It will either be the ID of the pool c
 map(object({
     username   = string
     email      = string
-    first_name = optional(string)
-    last_name  = optional(string)
+    first_name = string
+    last_name  = string
   }))
 ----
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,8 +51,8 @@ variable "user_map" {
   type = map(object({
     username   = string
     email      = string
-    first_name = optional(string)
-    last_name  = optional(string)
+    first_name = string
+    last_name  = string
   }))
   default = {}
 }


### PR DESCRIPTION
## Description of the changes

The two values `first_name` and `last_name` should not be optional because the code behind does not support it. If we were to omit these values, the module would not work. I think is is best to force these so the users are properly created with good values.

## Breaking change

- [x] No - this is not a breaking change because anyone not using these values would have already had a broken code

## Tests executed on which distribution(s)

- [x] EKS
