### PR TITLE
feat: add a subdomain variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -282,8 +282,8 @@ Description: ID of the Cognito user pool. It will either be the ID of the pool c
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_aws]] <<provider_aws,aws>> |>= 4
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -176,6 +176,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 
 Description: IDs of the other modules on which this module depends on.
@@ -310,6 +318,12 @@ Description: ID of the Cognito user pool. It will either be the ID of the pool c
 |`string`
 |n/a
 |yes
+
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
 
 |[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 |IDs of the other modules on which this module depends on.

--- a/README.adoc
+++ b/README.adoc
@@ -178,7 +178,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -320,7 +320,7 @@ Description: ID of the Cognito user pool. It will either be the ID of the pool c
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/locals.tf
+++ b/locals.tf
@@ -5,12 +5,12 @@ locals {
 
   # TODO Discuss if we use a coalescelist() instead of the concat()
   callback_urls = distinct(concat([
-    format("https://argocd.apps.%s.%s/auth/callback", var.cluster_name, var.base_domain),
-    format("https://grafana.apps.%s.%s/login/generic_oauth", var.cluster_name, var.base_domain),
-    format("https://prometheus.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
-    format("https://thanos-query.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
-    format("https://thanos-bucketweb.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
-    format("https://alertmanager.apps.%s.%s/oauth2/callback", var.cluster_name, var.base_domain),
+    format("https://argocd.%s.%s/auth/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://grafana.%s.%s/login/generic_oauth", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://prometheus.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://thanos-query.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://thanos-bucketweb.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://alertmanager.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
   ], var.callback_urls))
 
   oidc = {

--- a/locals.tf
+++ b/locals.tf
@@ -3,13 +3,18 @@ locals {
 
   cognito_user_pool_domain = var.create_pool ? resource.aws_cognito_user_pool_domain.devops_stack_user_pool_domain[0].domain : var.cognito_user_pool_domain
 
-  # TODO Discuss if we use a coalescelist() instead of the concat()
   callback_urls = distinct(concat([
+    format("https://argocd.%s/auth/callback", trimprefix("${var.subdomain}.${var.base_domain}", ".")),
     format("https://argocd.%s.%s/auth/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://grafana.%s/login/generic_oauth", trimprefix("${var.subdomain}.${var.base_domain}", ".")),
     format("https://grafana.%s.%s/login/generic_oauth", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://prometheus.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.base_domain}", ".")),
     format("https://prometheus.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://thanos-query.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.base_domain}", ".")),
     format("https://thanos-query.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://thanos-bucketweb.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.base_domain}", ".")),
     format("https://thanos-bucketweb.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
+    format("https://alertmanager.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.base_domain}", ".")),
     format("https://alertmanager.%s.%s/oauth2/callback", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain),
   ], var.callback_urls))
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "base_domain" {
 }
 
 variable "subdomain" {
-  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  description = "Subdomain of the cluster. Value used for the ingress' URL of the application."
   type        = string
   default     = "apps"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "base_domain" {
   type        = string
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "dependency_ids" {
   description = "IDs of the other modules on which this module depends on."
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@ variable "subdomain" {
   description = "Subdomain of the cluster. Value used for the ingress' URL of the application."
   type        = string
   default     = "apps"
+  nullable    = false
 }
 
 variable "dependency_ids" {


### PR DESCRIPTION
## Description of the changes

Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

## Breaking change

- [X] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)