### PR TITLE
fix: ignore any schema changes made on the remote side

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -138,9 +138,9 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_aws]] <<provider_aws,aws>> (>= 4)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,12 @@ resource "aws_cognito_user_pool" "devops_stack_user_pool" {
     allow_admin_create_user_only = true
   }
 
+  lifecycle {
+    ignore_changes = [
+      schema,
+    ]
+  }
+
   depends_on = [
     null_resource.dependencies,
   ]


### PR DESCRIPTION
## Description of the changes

I've been encountering an error when using the `create_pool` function of this module. Since we do not set any schema at creation, AWS takes care of setting it using their default values. However, Terraform is not aware of this and tries to put the values back to `null`, which is not supported, as the schema can only be defined at creation time. See:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.oidc.aws_cognito_user_pool.devops_stack_user_pool[0] will be updated in-place
  ~ resource "aws_cognito_user_pool" "devops_stack_user_pool" {
        id                        = "eu-west-1_ssoW8L9cr"
        name                      = "llm-models-sks-pool"
        tags                      = {}
        # (11 unchanged attributes hidden)

      - schema {
          - attribute_data_type      = "String" -> null
          - developer_only_attribute = false -> null
          - mutable                  = true -> null
          - name                     = "birthdate" -> null
          - required                 = false -> null

          - string_attribute_constraints {
              - max_length = "10" -> null
              - min_length = "4" -> null
            }
        }

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Warning: AWS account ID not found for provider
│ 
│   with provider["registry.terraform.io/hashicorp/aws"].exoscale-s3,
│   on terraform.tf line 38, in provider "aws":
│   38: provider "aws" {
│ 
│ See https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_requesting_account_id for implications.
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.oidc.aws_cognito_user_pool.devops_stack_user_pool[0]: Modifying... [id=eu-west-1_ssoW8L9cr]
╷
│ Error: updating Cognito User Pool (eu-west-1_ssoW8L9cr): cannot modify or remove schema items
│ 
│   with module.oidc.aws_cognito_user_pool.devops_stack_user_pool[0],
│   on .terraform/modules/oidc/main.tf line 5, in resource "aws_cognito_user_pool" "devops_stack_user_pool":
│    5: resource "aws_cognito_user_pool" "devops_stack_user_pool" {
│ 
╵
```

This is an issue already fixed in https://github.com/hashicorp/terraform-provider-aws/issues/21654 but it seems to have returned on latest versions in https://github.com/hashicorp/terraform-provider-aws/issues/38224.

Since the way to create the Cognito pool by this module is mainly used for quick deployments and not meant to be used in production, I propose we add an `ignore_changes` to avoid having this error. And since these values can only be set at creation time, it is kind of a mute point to have Terraform check for changes anyway.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS
